### PR TITLE
dyndns.py: raise error on first failed update call

### DIFF
--- a/dyndns.py
+++ b/dyndns.py
@@ -65,8 +65,8 @@ class PorkbunDNSAPIClient:
                 print(f"Editing {i['type']} record of {record_name}")
                 updateRecord = json.loads(requests.post(self.base_url + '/dns/edit/' + root_domain + '/' + i["id"], data = json.dumps(api_header)).text)
 
-        if updateRecord["status"] == "ERROR":
-            raise DNSAPIException(500, updateRecord['message'])
+            if updateRecord["status"] == "ERROR":
+                raise DNSAPIException(500, updateRecord['message'])
 
         return(updateRecord)
 


### PR DESCRIPTION
I think this improves the error handling in case of multiple records.

It's not perfect though, as `updateRecord` still only contains the last server response as far as my python understanding goes